### PR TITLE
rules.bzl: change cfg to exec

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -134,13 +134,13 @@ protoc_gen_protobufjs = rule(
         "_protoc": attr.label(
             default = "@com_google_protobuf//:protoc",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             allow_single_file = True,
         ),
         "_protoc_gen_protobufjs": attr.label(
             default = "@com_github_buildbuddy_io_protoc_gen_protobufjs//:protoc-gen-protobufjs",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             allow_single_file = True,
         ),
         "_implicit_imports": attr.label_list(


### PR DESCRIPTION
This helps us stop assuming that the local host platform (i.e. your
laptop) is always the execution platform. Effectively, it should let us
use a Linux protoc binary to build remotely even when Bazel was running
from a MacOS laptop.
