### PR TITLE
Use ubuntu-latest for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ permissions:
   contents: write
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repo
         uses: actions/checkout@v3


### PR DESCRIPTION
We're just using standard unix tools like `git` / `tar`, plus the `gh` CLI, so it seems like a safe bet to just use `ubuntu-latest` in order to keep this workflow green.